### PR TITLE
Add updated project descriptions with links

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -2,11 +2,36 @@ import React from 'react';
 
 function Projects() {
   return (
-    <section>
-      <h2>Projects</h2>
-      <p>Here I will showcase some of my projects.</p>
+    <section id="projects">
+      <h2>My Projects</h2>
+
+      <div className="project-card">
+        <h3>Workout Tracker</h3>
+        <p>A simple voice-based workout tracker that converts your speech into structured tables using Next.js and OpenAI API.</p>
+        <a href="https://github.com/CMPT-276-SUMMER-2025/final-project-9-pines" target="_blank" rel="noopener noreferrer">GitHub Repo</a>
+      </div>
+
+      <div className="project-card">
+        <h3>Study Scheduler</h3>
+        <p>A Python script that helps students plan study time based on class difficulty and energy levels.</p>
+        <a href="https://github.com/florykhan/study-scheduler" target="_blank" rel="noopener noreferrer">GitHub Repo</a>
+      </div>
+
+      <div className="project-card">
+        <h3>Portfolio Website</h3>
+        <p>
+          This very website — created with React, styled in CSS, and hosted on GitHub Pages.
+          Demonstrates clean Git practices, component structure, and deployment.
+        </p>
+        <a href="https://github.com/florykhan/florykhan.github.io.git" target="_blank" rel="noopener noreferrer">
+          View on GitHub
+        </a>
+      </div>
     </section>
+
+    
   );
 }
 
 export default Projects;
+


### PR DESCRIPTION
This pull request almost completes the `Projects` section of the portfolio website. It includes:

- Three real project cards:
  - **Workout Tracker** — Next.js app with OpenAI voice input
  - **Study Scheduler** — Python-based study planner script
  - **Portfolio** - this very project created with React, styled in CSS, and hosted on GitHub Pages.
- Project names, short descriptions, and links to GitHub repositories

No custom styling added yet — that will be done in a later commit.